### PR TITLE
Add AprilTag native library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,4 +40,7 @@ dependencies {
 
     implementation 'com.google.ar:core:1.14.0'
     // Using ARCore directly for lightweight tracking.
+
+    // AprilTag native detection library (includes prebuilt .so binaries)
+    implementation 'org.openftc:apriltag:2.1.0'
 }


### PR DESCRIPTION
## Summary
- include the AprilTag library from Maven
- ensure binaries are packaged

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_684120915da48322a3e385cc00cfa47d